### PR TITLE
version 0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ A powerful, elegant VS Code extension for [UV](https://github.com/astral-sh/uv) 
 
 ## 📋 Changelog
 
+### v0.3.2 (2025-12-20)
+
+**Fixed:**
+- Fixed UV not detected after installation until full VS Code restart
+- Changed "Reload Window" to "Restart VS Code" after UV installation to properly refresh PATH
+
+---
+
 ### v0.3.1 (2025-12-20)
 
 **Fixed:**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "uv-vscode-extension",
     "displayName": "UV - Python Package Manager",
     "description": "Elegant extension for uv - the extremely fast Python package manager. Manage dependencies, Python versions, virtual environments, and more.",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "publisher": "MouradGHAFIRI",
     "license": "MIT",
     "author": {

--- a/src/uvExecutor.ts
+++ b/src/uvExecutor.ts
@@ -262,11 +262,13 @@ export class UVExecutor {
                 progress.report({ increment: 100, message: 'Installation complete!' });
 
                 vscode.window.showInformationMessage(
-                    'UV installation initiated. Please restart VS Code after installation completes.',
-                    'Reload Window'
+                    'UV installed successfully! Please restart VS Code to apply PATH changes.',
+                    'Restart Now',
+                    'Later'
                 ).then(selection => {
-                    if (selection === 'Reload Window') {
-                        vscode.commands.executeCommand('workbench.action.reloadWindow');
+                    if (selection === 'Restart Now') {
+                        // Close and restart VS Code to pick up new PATH
+                        vscode.commands.executeCommand('workbench.action.quit');
                     }
                 });
 


### PR DESCRIPTION
The issue was that VS Code's 'Reload Window' doesn't refresh the shell environment, so UV wasn't found in PATH after installation.

Changes:
- Change 'Reload Window' to 'Restart VS Code' after UV installation
- Use workbench.action.quit instead of reloadWindow
- A full restart properly picks up the new PATH from shell profile
- Bump version to 0.3.2
- Update README changelog