### PR TITLE
version 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ A powerful, elegant VS Code extension for [UV](https://github.com/astral-sh/uv) 
 
 ## 📋 Changelog
 
+### v0.4.1 (2025-12-20)
+
+**Fixed:**
+- Fixed `.python-version` writing full toolchain ID instead of version number when switching Python versions
+
+---
+
 ### v0.4.0 (2025-12-20)
 
 **Added:**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "uv-vscode-extension",
     "displayName": "UV - Python Package Manager",
     "description": "Elegant extension for uv - the extremely fast Python package manager. Manage dependencies, Python versions, virtual environments, and more.",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "publisher": "MouradGHAFIRI",
     "license": "MIT",
     "author": {

--- a/src/uvExecutor.ts
+++ b/src/uvExecutor.ts
@@ -797,9 +797,9 @@ export class UVExecutor {
                         throw new Error(`No installed Python toolchain found for version ${version}. Please install it first.`);
                     }
 
-                    // Step 2: Update .python-version file with the toolchain ID
+                    // Step 2: Update .python-version file with the version number (not full toolchain ID)
                     progress.report({ increment: 20, message: 'Updating project configuration...' });
-                    await this.updatePythonVersionFile(workspaceRoot, toolchainId);
+                    await this.updatePythonVersionFile(workspaceRoot, version);
                     await this.updatePyprojectToml(workspaceRoot, version);
 
                     // Step 3: Remove existing virtual environment


### PR DESCRIPTION
The .python-version file was incorrectly being written with the full toolchain ID (e.g., 'cpython-3.13.1-macos-aarch64-none') instead of just the version number (e.g., '3.13.1').

Fixed by passing the version number to updatePythonVersionFile() instead of the toolchainId in switchProjectPythonVersion().

Changes:
- Bump version to 0.4.1
- Update README changelog